### PR TITLE
feat(event-hub): alarm 로직 비동기 처리

### DIFF
--- a/monicar-collector/src/main/resources/application.yml
+++ b/monicar-collector/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: prod
+    active: dev

--- a/monicar-control-center/src/main/resources/application-dev.yml
+++ b/monicar-control-center/src/main/resources/application-dev.yml
@@ -54,7 +54,7 @@ cookie:
 logging:
   config: classpath:logback-spring-dev.xml
   file:
-    path: ${user.dir}/logs
+    path: ./logs
 swagger:
   server:
     prod-url: ${PROD_URL}

--- a/monicar-emulator/src/main/resources/application.yml
+++ b/monicar-emulator/src/main/resources/application.yml
@@ -21,8 +21,8 @@ api:
 file-name: default_seoul-to-gyeongju_formatted.gpx
 
 fixed:
-  vehicle-mdn: 1234567890
-  vehicle-number: 123나1234
+  vehicle-mdn: 2254690422
+  vehicle-number: 657가5202
 
 ---
 server:
@@ -39,8 +39,8 @@ file-name: tomato_yangyang-to-daegu_formatted.gpx
 
 # rds vehicle_information 데이터 기준
 fixed:
-  vehicle-mdn: 2254690422
-  vehicle-number: 657가5202
+  vehicle-mdn: 1234567890
+  vehicle-number: 123나1234
 
 ---
 server:

--- a/monicar-event-hub/src/main/java/org/eventhub/application/AlarmService.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/application/AlarmService.java
@@ -6,20 +6,20 @@ import org.eventhub.application.port.AlarmRepository;
 import org.eventhub.application.port.AlarmSender;
 import org.eventhub.domain.Alarm;
 import org.eventhub.domain.AlarmStatus;
+import org.eventhub.domain.VehicleInformation;
 import org.eventhub.infrastructure.external.command.AlarmSend;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-
 @RequiredArgsConstructor
 @Service
 @Slf4j
 public class AlarmService {
+	private final VehicleService vehicleService;
 	private final AlarmRepository alarmRepository;
 	private final AlarmSender alarmSender;
 	@Value("${alarm-interval-distance}")
@@ -29,31 +29,30 @@ public class AlarmService {
 		return alarmRepository.findByVehicleId(vehicleId);
 	}
 
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	public Optional<Long> saveAlarmIfNecessary(Long vehicleId, Long totalDistance) {
+	@Async
+	public void sendAlarmIfNecessary(Long mdn) {
+		VehicleInformation vehicleInfo = vehicleService.getVehicleInformation(mdn);
+		Long vehicleId = vehicleInfo.getId();
+		Long totalDistance = vehicleInfo.getSum();
 		try {
 			Optional<Alarm> alarm = alarmRepository.findRecentOneByVehicleId(vehicleId);
 			int targetDistance = alarm.map(Alarm::getDrivingDistance).orElse(0);
 
 			if (checkBiggerThanIntervalDistance(totalDistance, targetDistance)) {
 				if (alarm.isEmpty() || alarm.get().getStatus().equals(AlarmStatus.COMPLETED)) {
-					return Optional.ofNullable(alarmRepository.save(vehicleId));
+					Long alarmId = alarmRepository.save(vehicleId);
+					sendAlarm(alarmId);
 				}
 			}
-			return Optional.empty();
 		} catch (Exception e) {
-			log.error("Alarm 쿼리 예외 발생", e);
+			log.error("알림 로직 예외 발생", e);
 		}
-		return Optional.empty();
 	}
 
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	public void sendAlarm(Long alarmId) {
-		try {
-			alarmSender.sendAlarm(AlarmSend.builder().alarmId(alarmId).build());
-		} catch (Exception e) {
-			log.info("something wrong: {}", e.getMessage());
-		}
+	private void sendAlarm(Long alarmId) {
+		alarmSender.sendAlarm(AlarmSend.builder()
+			.alarmId(alarmId)
+			.build());
 	}
 
 	private boolean checkBiggerThanIntervalDistance(long totalDistance, int drivingDistanceLastCheck) {

--- a/monicar-event-hub/src/main/java/org/eventhub/application/OnOffService.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/application/OnOffService.java
@@ -1,0 +1,82 @@
+package org.eventhub.application;
+
+import java.util.Optional;
+
+import org.eventhub.common.exception.BusinessException;
+import org.eventhub.common.response.ErrorCode;
+import org.eventhub.domain.DrivingHistoryCreate;
+import org.eventhub.domain.UpdateTotalDistance;
+import org.eventhub.domain.VehicleEvent;
+import org.eventhub.domain.VehicleEventType;
+import org.eventhub.domain.VehicleInformation;
+import org.eventhub.domain.VehicleOffEventCreate;
+import org.eventhub.domain.VehicleOnEventCreate;
+import org.eventhub.domain.VehicleStatus;
+import org.eventhub.presentation.request.KeyOffRequest;
+import org.eventhub.presentation.request.KeyOnRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class OnOffService {
+	private final VehicleService vehicleService;
+	private final VehicleEventService vehicleEventService;
+	private final DrivingHistoryService drivingHistoryService;
+
+	@Transactional
+	public void keyOn(final KeyOnRequest request) {
+		VehicleInformation vehicleInformation = vehicleService.getVehicleInformation(request.mdn());
+
+		Optional<VehicleEvent> vehicleEvent = vehicleEventService.getRecentVehicleEvent(vehicleInformation.getId());
+		boolean isAlreadyOn = vehicleEvent.map(VehicleEvent::isTypeOn).orElse(false);
+
+		log.info("is already ON? : {}! {}", isAlreadyOn, isAlreadyOn ? "" : "Engine ON");
+		if (isAlreadyOn) {
+			throw new BusinessException(ErrorCode.WRONG_APPROACH);
+		}
+		VehicleOnEventCreate vehicleOnEventCreate = request.toDomain(vehicleInformation.getId(), vehicleInformation.getSum());
+		vehicleEventService.saveVehicleEvent(vehicleOnEventCreate);
+
+		vehicleService.updateVehicleStatus(vehicleInformation.getId(), VehicleStatus.IN_OPERATION);
+	}
+
+	@Transactional
+	public void keyOff(final KeyOffRequest request) {
+		VehicleInformation vehicleInformation = vehicleService.getVehicleInformation(request.mdn());
+
+		Optional<VehicleEvent> vehicleEvent = vehicleEventService.getRecentVehicleEvent(vehicleInformation.getId());
+		boolean isAlreadyOff = vehicleEvent.map(VehicleEvent::isTypeOff).orElse(false);
+
+		log.info("is already OFF? : {}! {}", isAlreadyOff, isAlreadyOff ? "" : "Engine OFF");
+		if (isAlreadyOff) {
+			throw new BusinessException(ErrorCode.WRONG_APPROACH);
+		}
+
+		vehicleService.updateVehicleStatus(vehicleInformation.getId(), VehicleStatus.NOT_DRIVEN);
+
+		Long updatedTotalDistance = vehicleService.updateTotalDistance(UpdateTotalDistance.of(
+			vehicleInformation.getId(), request.sum()
+		));
+
+		drivingHistoryService.saveDrivingHistory(DrivingHistoryCreate.of(
+				vehicleInformation.getId(),
+				vehicleInformation.getCompanyId(),
+				updatedTotalDistance,
+				request.sum(),
+				vehicleEvent.get().getEventAt(),
+				request.offTime()
+			)
+		);
+
+		vehicleEventService.saveVehicleEvent(VehicleOffEventCreate.of(
+			vehicleInformation.getId(),
+			VehicleEventType.OFF,
+			request.offTime()
+		));
+	}
+}

--- a/monicar-event-hub/src/main/java/org/eventhub/config/AsyncConfig.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/config/AsyncConfig.java
@@ -1,0 +1,21 @@
+package org.eventhub.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+	@Bean
+	public ThreadPoolTaskExecutor taskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(5);
+		executor.setMaxPoolSize(10);
+		executor.setQueueCapacity(20);
+		executor.setThreadNamePrefix("AsyncExecutor-");
+		executor.initialize();
+		return executor;
+	}
+}

--- a/monicar-event-hub/src/main/java/org/eventhub/presentation/OnOffController.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/presentation/OnOffController.java
@@ -1,24 +1,10 @@
 package org.eventhub.presentation;
 
-import java.util.Optional;
-
 import org.eventhub.application.AlarmService;
-import org.eventhub.application.DrivingHistoryService;
-import org.eventhub.application.VehicleEventService;
-import org.eventhub.application.VehicleService;
+import org.eventhub.application.OnOffService;
 import org.eventhub.common.response.BaseResponse;
-import org.eventhub.common.response.ErrorCode;
-import org.eventhub.domain.DrivingHistoryCreate;
-import org.eventhub.domain.UpdateTotalDistance;
-import org.eventhub.domain.VehicleEvent;
-import org.eventhub.domain.VehicleEventType;
-import org.eventhub.domain.VehicleInformation;
-import org.eventhub.domain.VehicleOffEventCreate;
-import org.eventhub.domain.VehicleOnEventCreate;
-import org.eventhub.domain.VehicleStatus;
 import org.eventhub.presentation.request.KeyOffRequest;
 import org.eventhub.presentation.request.KeyOnRequest;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,9 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/v1/event-hub")
 @Slf4j
 public class OnOffController {
-	private final VehicleService vehicleService;
-	private final VehicleEventService vehicleEventService;
-	private final DrivingHistoryService drivingHistoryService;
+	private final OnOffService onOffService;
 	private final AlarmService alarmService;
 
 	@PostMapping("/key-on")
@@ -43,63 +27,19 @@ public class OnOffController {
 		@Valid @RequestBody final KeyOnRequest request
 	) {
 		log.info("emulator ON request in event-hub ! ");
-		VehicleInformation vehicleInformation = vehicleService.getVehicleInformation(request.mdn());
-
-		Optional<VehicleEvent> vehicleEvent = vehicleEventService.getRecentVehicleEvent(vehicleInformation.getId());
-		boolean isAlreadyOn = vehicleEvent.map(VehicleEvent::isTypeOn).orElse(false);
-
-		log.info("is already ON? : {}! {}", isAlreadyOn, isAlreadyOn ? "" : "Engine ON");
-		if (isAlreadyOn) {
-			return BaseResponse.fail(ErrorCode.WRONG_APPROACH);
-		}
-		VehicleOnEventCreate vehicleOnEventCreate = request.toDomain(vehicleInformation.getId(), vehicleInformation.getSum());
-		vehicleEventService.saveVehicleEvent(vehicleOnEventCreate);
-
-		vehicleService.updateVehicleStatus(vehicleInformation.getId(), VehicleStatus.IN_OPERATION);
+		onOffService.keyOn(request);
 
 		return BaseResponse.success();
 	}
 
-	@Transactional
 	@PostMapping("/key-off")
 	public BaseResponse keyOff(
 		@Valid @RequestBody final KeyOffRequest request
 	) {
 		log.info("emulator OFF request in event-hub ! ");
-		VehicleInformation vehicleInformation = vehicleService.getVehicleInformation(request.mdn());
 
-		Optional<VehicleEvent> vehicleEvent = vehicleEventService.getRecentVehicleEvent(vehicleInformation.getId());
-		boolean isAlreadyOff = vehicleEvent.map(VehicleEvent::isTypeOff).orElse(false);
-
-		log.info("is already OFF? : {}! {}", isAlreadyOff, isAlreadyOff ? "" : "Engine OFF");
-		if (isAlreadyOff) {
-			return BaseResponse.fail(ErrorCode.WRONG_APPROACH);
-		}
-
-		vehicleService.updateVehicleStatus(vehicleInformation.getId(), VehicleStatus.NOT_DRIVEN);
-
-		Long updatedTotalDistance = vehicleService.updateTotalDistance(UpdateTotalDistance.of(
-			vehicleInformation.getId(), request.sum()
-		));
-
-		drivingHistoryService.saveDrivingHistory(DrivingHistoryCreate.of(
-			vehicleInformation.getId(),
-			vehicleInformation.getCompanyId(),
-			updatedTotalDistance,
-			request.sum(),
-			vehicleEvent.get().getEventAt(),
-			request.offTime()
-			)
-		);
-
-		vehicleEventService.saveVehicleEvent(VehicleOffEventCreate.of(
-			vehicleInformation.getId(),
-			VehicleEventType.OFF,
-			request.offTime()
-		));
-
-		alarmService.saveAlarmIfNecessary(vehicleInformation.getId(), updatedTotalDistance)
-			.ifPresent(alarmService::sendAlarm);
+		onOffService.keyOff(request);
+		alarmService.sendAlarmIfNecessary(request.mdn());
 
 		return BaseResponse.success();
 	}


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

alarm 로직을 keyOff 로직과 분리하고, 비동기 처리 했습니다.

## 💡 리뷰어에게 하고 싶은 말

원래 alarm 로직은 keyOff 로직 중 하나였고 @Transactional(propagation = Propagation.REQUIRES_NEW)로 새로운 트랜잭션을 통해 처리했습니다. 알림 로직은 네트워크 I/O를 포함하는데, 네트워크 이슈 때문에 OFF 이벤트 저장이나 운행 내역 저장같은 중요한 데이터 변경도 롤백되는 것을 막기 위함이었습니다. 

그러나 네트워크 I/O를 트랜잭션에 포함시키는 것 자체가 잘못됐다고 판단했습니다. 네트워크 이슈때문에 트랜잭션 커밋이 지체되면 전체적인 성능에도 영향이 가기 때문입니다. alarm 로직을 keyOff 로직 밖으로 빼서 트랜잭션을 타지 않게 변경했고, alarm 로직에 @Async를 적용하여 비동기 처리 함으로써 off 요청 전체 응답 속도를 단축시켰습니다. 

알림 전송에 대한 실패 여부는 크게 중요하지 않다고 판단하여 콜백으로 응답을 받을 필요는 없습니다. 실패했다해도 다음 off 요청 때 똑같은 과정을 반복하기 때문에 재시도 로직 또한 따로 추가하지 않았습니다.
